### PR TITLE
Fix issue with workflow not working on `master` branch.

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -2,7 +2,8 @@ name: Robot Framework
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - "main"
    
 
 jobs:


### PR DESCRIPTION
@riteshkgupta395 You workflow was set to run on push to the `master` branch. However, your working branch is `main`. Thus the workflow file wasn't working whenever you pushed to that branch.

This PR should fix the issue!