### PR TITLE
Fix issues with the indentation in the workflow

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -19,8 +19,8 @@ jobs:
           env:
             BROWSER: chrome
             
-            name: Upload test results
-            uses: actions/upload-artifact@v1
+        - name: Upload test results
+          uses: actions/upload-artifact@v1
           if: always()
           with:
             name: reports
@@ -28,7 +28,7 @@ jobs:
    
     generate_report:
         if: always()
-        needs: [test]
+        needs: test
         runs-on: ubuntu-latest
         steps:
         - name: Download reports


### PR DESCRIPTION
@riteshkgupta395 This should fix the issue of the failing tests workflow.

The indentation for one of the steps was not correct and that's why the issue was happening!